### PR TITLE
Update README for meteor package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ See all sample pdf documents in `/samples`
 ### Install within a [Meteor project](http://meteor.com)
 
 [Review the documentation on Atmosphere for the most recent details on this
-package](https://atmospherejs.com/chipcastledotcom/jspdf-autotable).
+package](https://atmospherejs.com/jspdf/autotable).
 
-    meteor add chipcastledotcom:jspdf-autotable
+    meteor add jspdf:autotable
 
 ### Basic example
 


### PR DESCRIPTION
Since I'll be deprecating `chipcastledotcom:jspdf-autotable` from Atmosphere, I wanted to update the docs so we don't have any more users installing it.

My only concern is that installing this new package from Atmosphere shows version `1.3.0` as the latest, yet it appears from your tags that you're currently at `1.3.2`:
```
jspdf:autotable  1.3.0  jsPDF-AutoTable (official): generate PDF tables on the client-side (jspdf:core plugin)
```

I'll loop in @splendido to see if there's anything we need to do to get this updating properly.

Thanks!

